### PR TITLE
Unify section header widget

### DIFF
--- a/lib/app/themes/app_theme.dart
+++ b/lib/app/themes/app_theme.dart
@@ -16,6 +16,7 @@ export 'widgets/dialogs/app_info_dialog.dart';
 export 'widgets/feedback/app_snackbar.dart';
 export 'widgets/feedback/app_notice_card.dart';
 export 'widgets/layout/app_bar.dart';
+export 'widgets/layout/simple_section_header.dart';
 export 'widgets/states/app_empty_state.dart';
 export 'widgets/core/app_button.dart';
 export 'widgets/core/app_text_field.dart';

--- a/lib/app/themes/widgets/layout/simple_section_header.dart
+++ b/lib/app/themes/widgets/layout/simple_section_header.dart
@@ -1,0 +1,84 @@
+// lib/app/themes/widgets/layout/simple_section_header.dart
+import 'package:flutter/material.dart';
+import '../../theme_constants.dart';
+import '../../core/theme_extensions.dart';
+
+/// A reusable section header used across the app.
+class SimpleSectionHeader extends StatelessWidget {
+  final String title;
+  final String subtitle;
+  final IconData icon;
+  final VoidCallback? onTapRefresh;
+  final bool showRefresh;
+
+  const SimpleSectionHeader({
+    super.key,
+    required this.title,
+    required this.subtitle,
+    required this.icon,
+    this.onTapRefresh,
+    this.showRefresh = false,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.all(ThemeConstants.space4),
+      decoration: BoxDecoration(
+        color: context.cardColor,
+        borderRadius: BorderRadius.circular(ThemeConstants.radiusLg),
+      ),
+      child: Row(
+        children: [
+          // side indicator
+          Container(
+            width: 4,
+            height: 32,
+            decoration: BoxDecoration(
+              gradient: ThemeConstants.primaryGradient,
+              borderRadius: BorderRadius.circular(2),
+            ),
+          ),
+          ThemeConstants.space4.w,
+          // icon
+          Container(
+            padding: const EdgeInsets.all(ThemeConstants.space2),
+            decoration: BoxDecoration(
+              color: context.primaryColor.withValues(alpha: 0.1),
+              borderRadius: BorderRadius.circular(ThemeConstants.radiusMd),
+            ),
+            child: Icon(icon, color: context.primaryColor, size: ThemeConstants.iconMd),
+          ),
+          ThemeConstants.space3.w,
+          // texts
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  title,
+                  style: context.titleLarge?.copyWith(
+                    fontWeight: ThemeConstants.bold,
+                    color: context.textPrimaryColor,
+                  ),
+                ),
+                Text(
+                  subtitle,
+                  style: context.labelMedium?.copyWith(
+                    color: context.textSecondaryColor,
+                  ),
+                ),
+              ],
+            ),
+          ),
+          if (showRefresh && onTapRefresh != null)
+            IconButton(
+              onPressed: onTapRefresh,
+              icon: Icon(Icons.refresh, color: context.textSecondaryColor),
+              tooltip: 'تحديث',
+            ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/daily_quote/widgets/daily_quotes_card.dart
+++ b/lib/features/daily_quote/widgets/daily_quotes_card.dart
@@ -128,7 +128,13 @@ class _DailyQuotesCardState extends State<DailyQuotesCard> {
     return Column(
       children: [
         // عنوان القسم البسيط
-        _buildSimpleSectionHeader(context),
+        SimpleSectionHeader(
+          title: 'الاقتباس اليومي',
+          subtitle: 'آية وحديث وادعية مختارة',
+          icon: Icons.auto_stories_rounded,
+          showRefresh: !_isLoading,
+          onTapRefresh: _loadQuotes,
+        ),
         
         ThemeConstants.space4.h,
         
@@ -220,86 +226,8 @@ class _DailyQuotesCardState extends State<DailyQuotesCard> {
     );
   }
 
-  Widget _buildSimpleSectionHeader(BuildContext context) {
-    return Container(
-      decoration: BoxDecoration(
-        color: context.cardColor,
-        borderRadius: BorderRadius.circular(ThemeConstants.radiusXl),
-      ),
-      child: ClipRRect(
-        borderRadius: BorderRadius.circular(ThemeConstants.radiusXl),
-        child: BackdropFilter(
-          filter: ImageFilter.blur(sigmaX: 10, sigmaY: 10),
-          child: Material(
-            color: Colors.transparent,
-            child: Container(
-              decoration: BoxDecoration(
-                border: Border.all(
-                  color: context.dividerColor.withValues(alpha: 0.2),
-                  width: 1,
-                ),
-                borderRadius: BorderRadius.circular(ThemeConstants.radiusXl),
-              ),
-              child: Padding(
-                padding: const EdgeInsets.all(ThemeConstants.space4),
-                child: Row(
-                  children: [
-                    // أيقونة ثابتة
-                    Container(
-                      padding: const EdgeInsets.all(ThemeConstants.space2),
-                      decoration: BoxDecoration(
-                        gradient: ThemeConstants.primaryGradient,
-                        borderRadius: BorderRadius.circular(ThemeConstants.radiusMd),
-                      ),
-                      child: const Icon(
-                        Icons.auto_stories_rounded,
-                        color: Colors.white,
-                        size: 28,
-                      ),
-                    ),
-                    
-                    ThemeConstants.space4.w,
-                    
-                    // النصوص
-                    Expanded(
-                      child: Column(
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: [
-                          Text(
-                            'الاقتباس اليومي',
-                            style: context.titleLarge?.copyWith(
-                              fontWeight: ThemeConstants.bold,
-                            ),
-                          ),
-                          Text(
-                            'آية وحديث وادعية مختارة',
-                            style: context.labelMedium?.copyWith(
-                              color: context.textSecondaryColor,
-                            ),
-                          ),
-                        ],
-                      ),
-                    ),
-                    
-                    // زر إعادة التحديث
-                    if (!_isLoading)
-                      IconButton(
-                        onPressed: _loadQuotes,
-                        icon: Icon(
-                          Icons.refresh,
-                          color: context.textSecondaryColor,
-                        ),
-                        tooltip: 'تحديث الاقتباسات',
-                      ),
-                  ],
-                ),
-              ),
-            ),
-          ),
-        ),
-      ),
-    );
-  }
+  // Previously _buildSimpleSectionHeader was defined here but has been
+  // replaced with the reusable [SimpleSectionHeader] widget.
 
   Widget _buildSimpleQuoteCard(BuildContext context, QuoteData quote) {
     return Container(

--- a/lib/features/home/screens/home_screen.dart
+++ b/lib/features/home/screens/home_screen.dart
@@ -77,7 +77,11 @@ class _HomeScreenState extends State<HomeScreen> {
               ThemeConstants.space6.h,
               
               // عنوان الأقسام البسيط
-              _buildSimpleSectionHeader(context),
+              const SimpleSectionHeader(
+                title: 'الأقسام الرئيسية',
+                subtitle: 'اختر القسم المناسب لك',
+                icon: Icons.apps_rounded,
+              ),
               
               ThemeConstants.space4.h,
             ]),
@@ -95,66 +99,6 @@ class _HomeScreenState extends State<HomeScreen> {
     );
   }
 
-  Widget _buildSimpleSectionHeader(BuildContext context) {
-    return Container(
-      padding: const EdgeInsets.all(ThemeConstants.space4),
-      decoration: BoxDecoration(
-        color: context.cardColor,
-        borderRadius: BorderRadius.circular(ThemeConstants.radiusLg),
-      ),
-      child: Row(
-        children: [
-          // المؤشر الجانبي
-          Container(
-            width: 4,
-            height: 32,
-            decoration: BoxDecoration(
-              gradient: ThemeConstants.primaryGradient,
-              borderRadius: BorderRadius.circular(2),
-            ),
-          ),
-          
-          ThemeConstants.space4.w,
-          
-          // الأيقونة
-          Container(
-            padding: const EdgeInsets.all(ThemeConstants.space2),
-            decoration: BoxDecoration(
-              color: context.primaryColor.withValues(alpha: 0.1),
-              borderRadius: BorderRadius.circular(ThemeConstants.radiusMd),
-            ),
-            child: Icon(
-              Icons.apps_rounded,
-              color: context.primaryColor,
-              size: ThemeConstants.iconMd,
-            ),
-          ),
-          
-          ThemeConstants.space3.w,
-          
-          // النص
-          Expanded(
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Text(
-                  'الأقسام الرئيسية',
-                  style: context.titleLarge?.copyWith(
-                    fontWeight: ThemeConstants.bold,
-                    color: context.textPrimaryColor,
-                  ),
-                ),
-                Text(
-                  'اختر القسم المناسب لك',
-                  style: context.labelMedium?.copyWith(
-                    color: context.textSecondaryColor,
-                  ),
-                ),
-              ],
-            ),
-          ),
-        ],
-      ),
-    );
-  }
+  // Previously _buildSimpleSectionHeader was used here but has been
+  // replaced by the reusable [SimpleSectionHeader] widget.
 }


### PR DESCRIPTION
## Summary
- add `SimpleSectionHeader` widget for a consistent look across screens
- use the new header in `HomeScreen` and `DailyQuotesCard`
- export widget via `app_theme.dart`

## Testing
- `dart --version` *(fails: command not found)*
- `flutter format lib/app/themes/widgets/layout/simple_section_header.dart lib/features/home/screens/home_screen.dart lib/features/daily_quote/widgets/daily_quotes_card.dart lib/app/themes/app_theme.dart` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_6853f647d04483298d728a393ddc422d